### PR TITLE
AP-5533: Added get all corporate accounts for merchant method to Corp…

### DIFF
--- a/lib/apruve/resources/corporate_account.rb
+++ b/lib/apruve/resources/corporate_account.rb
@@ -3,9 +3,17 @@ module Apruve
     attr_accessor :id, :merchant_uuid, :customer_uuid, :type, :created_at, :updated_at, :payment_term_strategy_name,
                   :disabled_at, :name, :creditor_term_id, :payment_method_id, :status, :trusted_merchant
 
-    def self.find(merchant_id, email)
+    def self.find(merchant_id, email=nil)
+      if email.nil?
+        return find_all(merchant_id)
+      end
       response = Apruve.get("merchants/#{merchant_id}/corporate_accounts?email=#{email}")
-      return CorporateAccount.new(response.body.empty? ? {} : response.body[0])
+      CorporateAccount.new(response.body.empty? ? {} : response.body[0])
+    end
+
+    def self.find_all(merchant_id)
+      response = Apruve.get("merchants/#{merchant_id}/corporate_accounts")
+      response.body.map { |ca| CorporateAccount.new(ca.empty? ? {} : ca) }
     end
   end
 end

--- a/lib/apruve/resources/corporate_account.rb
+++ b/lib/apruve/resources/corporate_account.rb
@@ -1,7 +1,8 @@
 module Apruve
   class CorporateAccount < Apruve::ApruveObject
     attr_accessor :id, :merchant_uuid, :customer_uuid, :type, :created_at, :updated_at, :payment_term_strategy_name,
-                  :disabled_at, :name, :creditor_term_id, :payment_method_id, :status, :trusted_merchant
+                  :disabled_at, :name, :creditor_term_id, :payment_method_id, :status, :trusted_merchant,
+                  :authorized_buyers
 
     def self.find(merchant_id, email=nil)
       if email.nil?

--- a/spec/apruve/resources/corporate_account_spec.rb
+++ b/spec/apruve/resources/corporate_account_spec.rb
@@ -41,26 +41,40 @@ describe Apruve::CorporateAccount do
 
 
   describe '#find' do
-    describe 'success' do
+    context 'successful response' do
       let! (:stubs) do
         faraday_stubs do |stub|
           stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts?email=#{email}") { [200, {}, '{}'] }
         end
       end
-      it 'should do a get' do
+      it 'should get a corporate account' do
         Apruve::CorporateAccount.find(merchant_uuid, email)
         stubs.verify_stubbed_calls
       end
     end
 
-    describe 'not found' do
+    context 'when not found' do
       let! (:stubs) do
         faraday_stubs do |stub|
           stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts?email=#{email}") { [404, {}, 'Not Found'] }
         end
       end
-      it 'should raise' do
+      it 'should raise not found' do
         expect { Apruve::CorporateAccount.find(merchant_uuid, email) }.to raise_error(Apruve::NotFound)
+        stubs.verify_stubbed_calls
+      end
+    end
+  end
+
+  describe '#find_all' do
+    describe 'successful response' do
+      let! (:stubs) do
+        faraday_stubs do |stub|
+          stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts") { [200, {} ,  '{}'] }
+        end
+      end
+      it 'should get all corporate accounts for a merchant' do
+        Apruve::CorporateAccount.find_all(merchant_uuid)
         stubs.verify_stubbed_calls
       end
     end


### PR DESCRIPTION
I do not believe sinatra has the same kind of naming convention as rails does for model object methods. So I was not sure whether to make a new find_all since we are getting an array or just make email optional in find. If there is a more conventional way of doing what I did please let me know! 