### PR TITLE
AP-5542: Added Order#find_all to interface with the index endpoint, a…

### DIFF
--- a/lib/apruve/resources/order.rb
+++ b/lib/apruve/resources/order.rb
@@ -10,6 +10,16 @@ module Apruve
       Order.new(response.body)
     end
 
+    def self.find_all(merchant_order_id = nil)
+      if merchant_order_id.nil?
+        response = Apruve.get('orders')
+      else
+        response = Apruve.get("orders?merchant_order_id=#{merchant_order_id}")
+      end
+      logger.debug response.body
+      response.body.map { |order| Order.new(order) }
+    end
+
     def self.finalize!(id)
       response = Apruve.post("orders/#{id}/finalize")
       logger.debug response.body

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -145,7 +145,7 @@ describe Apruve::Order do
     context 'successful response' do
       let! (:stubs) do
         faraday_stubs do |stub|
-          stub.get('/api/v4/orders') { [200, {}, '{}'] }
+          stub.get('/api/v4/orders') { [200, {}, '[]'] }
         end
       end
       it 'should get all orders' do

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -141,6 +141,33 @@ describe Apruve::Order do
     end
   end
 
+  describe '#find_all' do
+    context 'successful response' do
+      let! (:stubs) do
+        faraday_stubs do |stub|
+          stub.get('/api/v4/orders') { [200, {}, '{}'] }
+        end
+      end
+      it 'should get all orders' do
+        Apruve::Order.find_all
+        stubs.verify_stubbed_calls
+      end
+    end
+
+    context 'with invalid merchant_order_id query param' do
+      let (:invalid_id) { '123' }
+      let! (:stubs) do
+        faraday_stubs do |stub|
+          stub.get("api/v4/orders?merchant_order_id=#{invalid_id}") { [200, {}, '[]']}
+        end
+      end
+      it 'should return an empty array' do
+        Apruve::Order.find_all(invalid_id)
+        stubs.verify_stubbed_calls
+      end
+    end
+  end
+
   describe '#save' do
     let (:id) { '89ea2488fe0a5c7bb38aa7f9b088874a' }
     let (:status) { 'pending' }


### PR DESCRIPTION
Do I need to do anything different to test presence/validity of merchant_order_id when using the stubbed calls? I have not yet encountered testing query params w/ Faraday, and am still a bit confused on how the faraday stubs are working 😬 