### PR TITLE
AP-5710 Corporate account find method does not URL encode the email address parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apruve (1.1.2)
+    apruve (1.1.6)
       addressable (~> 2.3)
       faraday (>= 0.8.6, <= 0.9.0)
       faraday_middleware (~> 0.9)
@@ -123,4 +123,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/lib/apruve/resources/apruve_object.rb
+++ b/lib/apruve/resources/apruve_object.rb
@@ -1,7 +1,6 @@
 module Apruve
   class ApruveObject
     require 'json'
-    require 'open-uri'
 
     def initialize(args = {})
       args.each do |k, v|

--- a/lib/apruve/resources/apruve_object.rb
+++ b/lib/apruve/resources/apruve_object.rb
@@ -1,6 +1,7 @@
 module Apruve
   class ApruveObject
     require 'json'
+    require 'open-uri'
 
     def initialize(args = {})
       args.each do |k, v|

--- a/lib/apruve/resources/corporate_account.rb
+++ b/lib/apruve/resources/corporate_account.rb
@@ -8,6 +8,7 @@ module Apruve
       if email.nil?
         return find_all(merchant_id)
       end
+      email = URI::encode(email)
       response = Apruve.get("merchants/#{merchant_id}/corporate_accounts?email=#{email}")
       CorporateAccount.new(response.body.empty? ? {} : response.body[0])
     end

--- a/lib/apruve/resources/corporate_account.rb
+++ b/lib/apruve/resources/corporate_account.rb
@@ -8,7 +8,7 @@ module Apruve
       if email.nil?
         return find_all(merchant_id)
       end
-      email = URI::encode(email)
+      email = CGI::escape(email)
       response = Apruve.get("merchants/#{merchant_id}/corporate_accounts?email=#{email}")
       CorporateAccount.new(response.body.empty? ? {} : response.body[0])
     end

--- a/lib/apruve/version.rb
+++ b/lib/apruve/version.rb
@@ -1,3 +1,3 @@
 module Apruve
-  VERSION = '1.1.5'
+  VERSION = '1.1.6'
 end

--- a/spec/apruve/resources/corporate_account_spec.rb
+++ b/spec/apruve/resources/corporate_account_spec.rb
@@ -55,9 +55,10 @@ describe Apruve::CorporateAccount do
     end
 
     context 'email with special characters' do
+      let!(:encoded_email) { CGI::escape(special_email) }
       let! (:stubs) do
         faraday_stubs do |stub|
-          stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts?email=#{special_email}") { [200, {}, '{}'] }
+          stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts?email=#{encoded_email}") { [200, {}, '{}'] }
         end
       end
       it 'should get a corporate account' do

--- a/spec/apruve/resources/corporate_account_spec.rb
+++ b/spec/apruve/resources/corporate_account_spec.rb
@@ -12,6 +12,7 @@ describe Apruve::CorporateAccount do
   let (:payment_term_strategy_name) { 'EOMNet15' }
   let (:name) { 'A name' }
   let (:email) { Faker::Internet.email }
+  let(:special_email) { 'foo+test@example.com' }
 
   let (:corporate_account) do
     Apruve::CorporateAccount.new(
@@ -49,6 +50,18 @@ describe Apruve::CorporateAccount do
       end
       it 'should get a corporate account' do
         Apruve::CorporateAccount.find(merchant_uuid, email)
+        stubs.verify_stubbed_calls
+      end
+    end
+
+    context 'email with special characters' do
+      let! (:stubs) do
+        faraday_stubs do |stub|
+          stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts?email=#{special_email}") { [200, {}, '{}'] }
+        end
+      end
+      it 'should get a corporate account' do
+        Apruve::CorporateAccount.find(merchant_uuid, special_email)
         stubs.verify_stubbed_calls
       end
     end


### PR DESCRIPTION
Allows emails with qualifiers (+/&/etc) to query corporate accounts for a merchant.