### PR TITLE
AP-5601: apruve-ruby Invoice object does not include all attributes provided by the API

### DIFF
--- a/lib/apruve/resources/invoice.rb
+++ b/lib/apruve/resources/invoice.rb
@@ -1,7 +1,8 @@
 module Apruve
   class Invoice < Apruve::ApruveObject
-    attr_accessor :id, :order_id, :status, :amount_cents, :currency, :merchant_notes, :merchant_invoice_id, :shipping_cents,
-                  :tax_cents, :invoice_items, :payments, :created_at, :opened_at, :due_at, :final_state_at, :issue_on_create, :links
+    attr_accessor :id, :order_id, :status, :amount_cents, :currency, :merchant_notes, :merchant_invoice_id,
+                  :shipping_cents, :tax_cents, :invoice_items, :payments, :created_at, :opened_at, :due_at,
+                  :final_state_at, :issue_on_create, :links, :issued_at, :amount_due
 
     def self.find(id)
       response = Apruve.get("invoices/#{id}")

--- a/spec/apruve/resources/invoice_spec.rb
+++ b/spec/apruve/resources/invoice_spec.rb
@@ -31,6 +31,8 @@ describe Apruve::Invoice do
   it { should respond_to(:due_at) }
   it { should respond_to(:final_state_at) }
   it { should respond_to(:links) }
+  it { should respond_to(:issued_at) }
+  it { should respond_to(:amount_due) }
 
   describe '#to_json' do
     let(:expected) do


### PR DESCRIPTION
Updated invoice object to include issued_at and amount_due, which were missing