### PR TITLE
AP-5494: Added lockable configure method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ test.apruve.com for test accounts.
 
 ### Initialize the library
 
-For [test.apruve.com](test.apruve.com)
+For [test.apruve.com](https://test.apruve.com/)
     Apruve.configure('YOUR_APRUVE_API_KEY', 'test')
 
-For [app.apruve.com](app.apruve.com)
+For [app.apruve.com](https://app.apruve.com)
     Apruve.configure('YOUR_APRUVE_API_KEY', 'prod')
 
 ### Create an Order

--- a/lib/apruve.rb
+++ b/lib/apruve.rb
@@ -1,6 +1,7 @@
 # $:.unshift File.join(File.dirname(__FILE__), 'apruve', 'resources')
 # $:.unshift File.join(File.dirname(__FILE__), 'apruve', 'response')
 
+require 'thread'
 require_relative 'apruve/client'
 require_relative 'apruve/version'
 require_relative 'apruve/error'
@@ -16,6 +17,7 @@ module Apruve
       :port => 3000,
       :version => 'v4',
   }
+  @mutex = Mutex.new
 
   class << self
 
@@ -30,6 +32,13 @@ module Apruve
       configure_environment environment
       @config = @config.merge(options)
       @client = Apruve::Client.new(api_key, @config)
+    end
+
+    def configure_with_lock(api_key=nil, environment=LOCAL, options={})
+      @mutex.synchronize do
+        configure(api_key, environment, options)
+        yield
+      end
     end
 
     def js(display=nil)

--- a/lib/apruve.rb
+++ b/lib/apruve.rb
@@ -1,7 +1,6 @@
 # $:.unshift File.join(File.dirname(__FILE__), 'apruve', 'resources')
 # $:.unshift File.join(File.dirname(__FILE__), 'apruve', 'response')
 
-require 'thread'
 require_relative 'apruve/client'
 require_relative 'apruve/version'
 require_relative 'apruve/error'
@@ -17,7 +16,6 @@ module Apruve
       :port => 3000,
       :version => 'v4',
   }
-  @mutex = Mutex.new
 
   class << self
 
@@ -32,13 +30,6 @@ module Apruve
       configure_environment environment
       @config = @config.merge(options)
       @client = Apruve::Client.new(api_key, @config)
-    end
-
-    def configure_with_lock(api_key=nil, environment=LOCAL, options={})
-      @mutex.synchronize do
-        configure(api_key, environment, options)
-        yield
-      end
     end
 
     def js(display=nil)

--- a/lib/apruve.rb
+++ b/lib/apruve.rb
@@ -9,14 +9,6 @@ require_relative 'apruve/faraday_error_handler'
 require_relative 'apruve/utils'
 
 module Apruve
-  Thread.current[:client] = nil
-  Thread.current[:config] = {
-    scheme: 'http',
-    host: 'localhost',
-    port: 3000,
-    version: 'v4'
-  }
-
   class << self
     PROD = 'prod'.freeze
     TEST = 'test'.freeze
@@ -28,6 +20,14 @@ module Apruve
     end
 
     def config
+      if Thread.current[:config].nil?
+        Thread.current[:config] = {
+          scheme: 'http',
+          host: 'localhost',
+          port: 3000,
+          version: 'v4'
+        }
+      end
       Thread.current[:config]
     end
 

--- a/spec/apruve/apruve_spec.rb
+++ b/spec/apruve/apruve_spec.rb
@@ -132,4 +132,21 @@ describe 'Apruve' do
       end
     end
   end
+
+  describe 'with multiple threads' do
+    let(:api_key) { 'an-api-key' }
+    let(:another_api_key) { 'another-api-key' }
+
+    it 'should have thread-contained configuration' do
+      Apruve.configure(api_key)
+      thread = Thread.new do
+        Apruve.configure(another_api_key)
+        expect(Apruve.client).not_to be_nil
+        expect(Apruve.client.api_key).to eq another_api_key
+      end
+      thread.join
+      expect(Apruve.client).not_to be_nil
+      expect(Apruve.client.api_key).to eq api_key
+    end
+  end
 end


### PR DESCRIPTION
Just want feedback on implementation before I move on to specs.

Basically now in multithreaded environments, e.g. the shopify gateway, we can do all our stuff in a configuration block. E.g.

this:
```ruby
Apruve.configure(@shop.api_key, @shop.mode, logger: logger)
order = Apruve::Order.find(params['entity']['id'])
# some other stuff
```
becomes:
```ruby
Apruve.configure_with_lock(@shop.api_key, @shop.mode, logger: logger) do
  order = Apruve::Order.find(params['entity']['id'])
  # some other stuff
end
```

Let me know what you think and I'll move forward, obviously this would mean some resulting changes in the Shopify gateway and any other environment where we use multiple threads like that.