### PR TITLE
AP-6242 OrderItem does not follow documented v4 API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apruve (1.1.7)
+    apruve (2.0.0)
       addressable (~> 2.3)
       faraday (>= 0.8.6, <= 0.9.0)
       faraday_middleware (~> 0.9)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For [app.apruve.com](https://app.apruve.com)
           sku: 'LTR-20R',
           price_ea_cents: 1200,
           quantity: 3,
-          amount_cents: 3600,
+          price_total_cents: 3600,
           view_product_url: 'https://www.example.com/letter-paper'
       )
 

--- a/lib/apruve/resources/order.rb
+++ b/lib/apruve/resources/order.rb
@@ -81,7 +81,7 @@ module Apruve
 
       # add the line items
       self.order_items.each do |item|
-        str += "#{item.title}#{item.plan_code}#{item.amount_cents}#{item.price_ea_cents}"\
+        str += "#{item.title}#{item.plan_code}#{item.price_total_cents}#{item.price_ea_cents}"\
         "#{item.quantity}#{item.merchant_notes}#{item.description}#{item.variant_info}#{item.sku}"\
         "#{item.vendor}#{item.view_product_url}"
       end

--- a/lib/apruve/resources/order_item.rb
+++ b/lib/apruve/resources/order_item.rb
@@ -1,6 +1,6 @@
 module Apruve
   class OrderItem < Apruve::ApruveObject
-    attr_accessor :id, :title, :amount_cents, :price_ea_cents, :quantity, :description, :merchant_notes,
+    attr_accessor :id, :title, :price_total_cents, :price_ea_cents, :quantity, :description, :merchant_notes,
                   :variant_info, :sku, :vendor, :view_product_url, :plan_code, :line_item_api_url,
                   :subscription_url
 

--- a/spec/apruve/resources/order_item_spec.rb
+++ b/spec/apruve/resources/order_item_spec.rb
@@ -10,7 +10,7 @@ describe Apruve::OrderItem do
   subject { line_item }
 
   it { should respond_to(:title) }
-  it { should respond_to(:amount_cents) }
+  it { should respond_to(:price_total_cents) }
   it { should respond_to(:price_ea_cents) }
   it { should respond_to(:quantity) }
   it { should respond_to(:description) }

--- a/spec/apruve/resources/order_item_spec.rb
+++ b/spec/apruve/resources/order_item_spec.rb
@@ -4,7 +4,7 @@ describe Apruve::OrderItem do
   let (:line_item) do
     Apruve::OrderItem.new(
         title: 'line 2',
-        amount_cents: '40'
+        price_total_cents: '40'
     )
   end
   subject { line_item }

--- a/spec/apruve/resources/subscription_spec.rb
+++ b/spec/apruve/resources/subscription_spec.rb
@@ -27,7 +27,7 @@ describe Apruve::Subscription do
 
   # from line_item
   it { should respond_to(:title) }
-  it { should respond_to(:amount_cents) }
+  it { should respond_to(:price_total_cents) }
   it { should respond_to(:price_ea_cents) }
   it { should respond_to(:quantity) }
   it { should respond_to(:description) }


### PR DESCRIPTION
This one flew under the radar for a while - our gem now meshes with the [documented attributes](https://docs.apruve.com/v4.0/reference#get_order-items-id) for `OrderItems` in our API.