### PR TITLE
AP-6456: attr method instead of hash lookup

### DIFF
--- a/lib/apruve/resources/order.rb
+++ b/lib/apruve/resources/order.rb
@@ -25,7 +25,7 @@ module Apruve
       response = Apruve.get("orders?secure_hash=#{hash}")
       logger.debug response.body
       orders = response.body.map { |order| Order.new(order) }
-      orders.max_by { |order| order[:created_at] }
+      orders.max_by { |order| order.created_at }
     end
 
     def self.finalize!(id)


### PR DESCRIPTION
Turns out this was all it needed, must not have updated in the running app without a restart.
