### PR TITLE
AP-6889: corporateaccount find by uuid

### DIFF
--- a/lib/apruve/resources/corporate_account.rb
+++ b/lib/apruve/resources/corporate_account.rb
@@ -17,5 +17,10 @@ module Apruve
       response = Apruve.get("merchants/#{merchant_id}/corporate_accounts")
       response.body.map { |ca| CorporateAccount.new(ca.empty? ? {} : ca) }
     end
+
+    def self.find_by_uuid(merchant_id, uuid)
+      response = Apruve.get("merchants/#{merchant_id}/corporate_accounts/#{uuid}")
+      CorporateAccount.new response.body
+    end
   end
 end

--- a/spec/apruve/resources/corporate_account_spec.rb
+++ b/spec/apruve/resources/corporate_account_spec.rb
@@ -96,4 +96,30 @@ describe Apruve::CorporateAccount do
       end
     end
   end
+
+  describe '#find_by_uuid' do
+    context 'successful response' do
+      let! (:stubs) do
+        faraday_stubs do |stub|
+          stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts/#{id}") { [200, {} , '{}'] }
+        end
+      end
+      it 'should return the corporate account' do
+        Apruve::CorporateAccount.find_by_uuid(merchant_uuid, id)
+        stubs.verify_stubbed_calls
+      end
+    end
+
+    context 'when not found' do
+      let! (:stubs) do
+        faraday_stubs do |stub|
+          stub.get("/api/v4/merchants/#{merchant_uuid}/corporate_accounts/#{id}") { [404, {} , 'Not Found'] }
+        end
+      end
+      it 'should raise not found' do
+        expect { Apruve::CorporateAccount.find_by_uuid(merchant_uuid, id) }.to raise_error(Apruve::NotFound)
+        stubs.verify_stubbed_calls
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding new endpoint for corporate_account find by uuid.

Normally this would be a find() method, but to retain compatibility, I used `find_by_uuid`.

