### PR TITLE
AP-8364 add missing po_number methods

### DIFF
--- a/lib/apruve/resources/order.rb
+++ b/lib/apruve/resources/order.rb
@@ -1,9 +1,9 @@
 module Apruve
   class Order < Apruve::ApruveObject
     attr_accessor :id, :merchant_id, :shopper_id, :merchant_order_id, :status, :amount_cents, :currency, :tax_cents,
-                  :shipping_cents, :expire_at, :order_items, :accepts_payments_via, :accepts_payment_terms, :payment_term,
-                  :created_at, :updated_at, :final_state_at, :default_payment_method, :links, :finalize_on_create, :invoice_on_create,
-                  :secure_hash
+                  :shipping_cents, :expire_at, :order_items, :accepts_payments_via, :accepts_payment_terms,
+                  :payment_term, :po_number, :created_at, :updated_at, :final_state_at, :default_payment_method, :links,
+                  :finalize_on_create, :invoice_on_create, :secure_hash
 
     def self.find(id)
       response = Apruve.get("orders/#{id}")

--- a/lib/apruve/version.rb
+++ b/lib/apruve/version.rb
@@ -1,3 +1,3 @@
 module Apruve
-  VERSION = '2.0.7'
+  VERSION = '2.0.8'
 end

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -60,6 +60,7 @@ describe Apruve::Order do
   it { should respond_to(:finalize_on_create) }
   it { should respond_to(:invoice_on_create) }
   it { should respond_to(:secure_hash) }
+  it { should respond_to(:po_number) }
 
   describe '#to_json' do
     let(:expected) do


### PR DESCRIPTION
This is preventing integrations from changing/setting the PO number on an Order after it is initially created.