### PR TITLE
AP-8715 Get payment term data from the correct attribute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apruve (2.0.7)
+    apruve (2.0.9)
       addressable (~> 2.3)
       faraday (>= 0.8.6, <= 0.9.0)
       faraday_middleware (~> 0.9)

--- a/lib/apruve/resources/order.rb
+++ b/lib/apruve/resources/order.rb
@@ -2,7 +2,7 @@ module Apruve
   class Order < Apruve::ApruveObject
     attr_accessor :id, :merchant_id, :shopper_id, :merchant_order_id, :status, :amount_cents, :currency, :tax_cents,
                   :shipping_cents, :expire_at, :order_items, :accepts_payments_via, :accepts_payment_terms,
-                  :payment_term, :po_number, :created_at, :updated_at, :final_state_at, :default_payment_method, :links,
+                  :payment_terms, :po_number, :created_at, :updated_at, :final_state_at, :default_payment_method, :links,
                   :finalize_on_create, :invoice_on_create, :secure_hash
 
     def self.find(id)
@@ -102,6 +102,16 @@ module Apruve
         raise 'api_key has not been set. Set it with Apruve.configure(api_key, environment, options)'
       end
       Digest::SHA256.hexdigest(Apruve.client.api_key+value_string)
+    end
+
+    # The field is actually named 'payment_terms', but some integrations are currently using 'payment_term'.  Pass
+    # those requests through to the correct attribute.
+    def payment_term
+      self.payment_terms
+    end
+
+    def payment_term=(pt)
+      self.payment_terms=pt
     end
   end
 end

--- a/lib/apruve/version.rb
+++ b/lib/apruve/version.rb
@@ -1,3 +1,3 @@
 module Apruve
-  VERSION = '2.0.8'
+  VERSION = '2.0.9'
 end

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -41,7 +41,7 @@ describe Apruve::Order do
         order_items: order_items,
         finalize_on_create: false,
         invoice_on_create: false,
-        payment_term: payment_term,
+        payment_terms: payment_term,
         secure_hash: 'fffd123'
     )
   end
@@ -61,13 +61,15 @@ describe Apruve::Order do
   it { should respond_to(:invoice_on_create) }
   it { should respond_to(:secure_hash) }
   it { should respond_to(:po_number) }
+  it { should respond_to(:payment_term) }
+  it { should respond_to(:payment_terms) }
 
   describe '#to_json' do
     let(:expected) do
       "{\"merchant_id\":\"9a9c3389fdc281b5c6c8d542a7e91ff6\",\"shopper_id\":\"9bc388fd08ce2835cfeb2e630316f7f1\",\"merchant_order_id\":\"ABC\","\
       "\"amount_cents\":12340,\"tax_cents\":0,\"shipping_cents\":0,\"order_items\":[{\"title\":\"line 1\",\"price_ea_cents\":\"123\",\"quantity\":10,"\
       "\"description\":\"A line item\",\"variant_info\":\"small\",\"sku\":\"LINE1SKU\",\"vendor\":\"acme, inc.\",\"view_product_url\":\"http://www.apruve.com/doc\""\
-      "},{\"title\":\"line 2\",\"price_ea_cents\":\"40\"}],\"finalize_on_create\":false,\"invoice_on_create\":false,\"payment_term\":{\"corporate_account_id\":\"612e5383e4acc6c2213f3cae6208e868\"},\"secure_hash\":\"fffd123\"}"
+      "},{\"title\":\"line 2\",\"price_ea_cents\":\"40\"}],\"finalize_on_create\":false,\"invoice_on_create\":false,\"payment_terms\":{\"corporate_account_id\":\"612e5383e4acc6c2213f3cae6208e868\"},\"secure_hash\":\"fffd123\"}"
     end
     its(:to_json) { should eq expected }
   end
@@ -274,7 +276,7 @@ describe Apruve::Order do
 
   describe '#update' do
     let (:id) { '89ea2488fe0a5c7bb38aa7f9b088874a' }
-    let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_term: payment_term }
+    let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_terms: payment_term }
     describe 'success' do
       let! (:stubs) do
         faraday_stubs do |stub|
@@ -296,6 +298,23 @@ describe Apruve::Order do
       it 'should raise' do
         expect { order.update! }.to raise_error(Apruve::NotFound)
         stubs.verify_stubbed_calls
+      end
+    end
+
+    describe '#payment_term' do
+      let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_terms: payment_term }
+
+      it 'returns payment_terms' do
+        expect(order.payment_term).to be order.payment_terms
+      end
+    end
+
+    describe '#payment_term=' do
+      let (:order) { Apruve::Order.new id: id, merchant_id: 9999 }
+
+      it 'sets payment_terms' do
+        order.payment_term = payment_term
+        expect(order.payment_terms).to be payment_term
       end
     end
   end


### PR DESCRIPTION
The API sends payment term data in an attribute named `payment_terms`, not `payment_term`.  This is a backwards-compatible fix for anything that might be using the currently implemented, incorrect attribute.