### PR TITLE
AP-8880: Reverting back to payment_term

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apruve (2.0.9)
+    apruve (2.0.10)
       addressable (~> 2.3)
       faraday (>= 0.8.6, <= 0.9.0)
       faraday_middleware (~> 0.9)
@@ -126,4 +126,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/apruve/resources/order.rb
+++ b/lib/apruve/resources/order.rb
@@ -2,7 +2,7 @@ module Apruve
   class Order < Apruve::ApruveObject
     attr_accessor :id, :merchant_id, :shopper_id, :merchant_order_id, :status, :amount_cents, :currency, :tax_cents,
                   :shipping_cents, :expire_at, :order_items, :accepts_payments_via, :accepts_payment_terms,
-                  :payment_terms, :po_number, :created_at, :updated_at, :final_state_at, :default_payment_method, :links,
+                  :payment_term, :po_number, :created_at, :updated_at, :final_state_at, :default_payment_method, :links,
                   :finalize_on_create, :invoice_on_create, :secure_hash
 
     def self.find(id)
@@ -104,14 +104,14 @@ module Apruve
       Digest::SHA256.hexdigest(Apruve.client.api_key+value_string)
     end
 
-    # The field is actually named 'payment_terms', but some integrations are currently using 'payment_term'.  Pass
+    # The field is actually named 'payment_term', but some integrations are currently using 'payment_terms'.  Pass
     # those requests through to the correct attribute.
-    def payment_term
-      self.payment_terms
+    def payment_terms
+      self.payment_term
     end
 
-    def payment_term=(pt)
-      self.payment_terms=pt
+    def payment_terms=(pt)
+      self.payment_term=pt
     end
   end
 end

--- a/lib/apruve/version.rb
+++ b/lib/apruve/version.rb
@@ -1,3 +1,3 @@
 module Apruve
-  VERSION = '2.0.9'
+  VERSION = '2.0.10'
 end

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -41,7 +41,7 @@ describe Apruve::Order do
         order_items: order_items,
         finalize_on_create: false,
         invoice_on_create: false,
-        payment_terms: payment_term,
+        payment_term: payment_term,
         secure_hash: 'fffd123'
     )
   end
@@ -69,7 +69,7 @@ describe Apruve::Order do
       "{\"merchant_id\":\"9a9c3389fdc281b5c6c8d542a7e91ff6\",\"shopper_id\":\"9bc388fd08ce2835cfeb2e630316f7f1\",\"merchant_order_id\":\"ABC\","\
       "\"amount_cents\":12340,\"tax_cents\":0,\"shipping_cents\":0,\"order_items\":[{\"title\":\"line 1\",\"price_ea_cents\":\"123\",\"quantity\":10,"\
       "\"description\":\"A line item\",\"variant_info\":\"small\",\"sku\":\"LINE1SKU\",\"vendor\":\"acme, inc.\",\"view_product_url\":\"http://www.apruve.com/doc\""\
-      "},{\"title\":\"line 2\",\"price_ea_cents\":\"40\"}],\"finalize_on_create\":false,\"invoice_on_create\":false,\"payment_terms\":{\"corporate_account_id\":\"612e5383e4acc6c2213f3cae6208e868\"},\"secure_hash\":\"fffd123\"}"
+      "},{\"title\":\"line 2\",\"price_ea_cents\":\"40\"}],\"finalize_on_create\":false,\"invoice_on_create\":false,\"payment_term\":{\"corporate_account_id\":\"612e5383e4acc6c2213f3cae6208e868\"},\"secure_hash\":\"fffd123\"}"
     end
     its(:to_json) { should eq expected }
   end
@@ -276,7 +276,7 @@ describe Apruve::Order do
 
   describe '#update' do
     let (:id) { '89ea2488fe0a5c7bb38aa7f9b088874a' }
-    let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_terms: payment_term }
+    let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_term: payment_term }
     describe 'success' do
       let! (:stubs) do
         faraday_stubs do |stub|
@@ -302,10 +302,10 @@ describe Apruve::Order do
     end
 
     describe '#payment_term' do
-      let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_terms: payment_term }
+      let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_term: payment_term }
 
       it 'returns payment_terms' do
-        expect(order.payment_term).to be order.payment_terms
+        expect(order.payment_term).to be order.payment_term
       end
     end
 

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -304,7 +304,7 @@ describe Apruve::Order do
     describe '#payment_terms' do
       let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_term: payment_term }
 
-      it 'returns payment_terms' do
+      it 'returns payment_term' do
         expect(order.payment_terms).to be order.payment_term
       end
     end

--- a/spec/apruve/resources/order_spec.rb
+++ b/spec/apruve/resources/order_spec.rb
@@ -301,19 +301,19 @@ describe Apruve::Order do
       end
     end
 
-    describe '#payment_term' do
+    describe '#payment_terms' do
       let (:order) { Apruve::Order.new id: id, merchant_id: 9999, payment_term: payment_term }
 
       it 'returns payment_terms' do
-        expect(order.payment_term).to be order.payment_term
+        expect(order.payment_terms).to be order.payment_term
       end
     end
 
-    describe '#payment_term=' do
+    describe '#payment_terms=' do
       let (:order) { Apruve::Order.new id: id, merchant_id: 9999 }
 
       it 'sets payment_terms' do
-        order.payment_term = payment_term
+        order.payment_terms = payment_term
         expect(order.payment_terms).to be payment_term
       end
     end


### PR DESCRIPTION
I left `:payment_terms` and `:payment_terms=` methods just in case, but if you think that is a bad idea I can revert that too.